### PR TITLE
Added final switch, dup/idup, vector operations, string switch

### DIFF
--- a/source/lwdr/string_switch.d
+++ b/source/lwdr/string_switch.d
@@ -1,0 +1,211 @@
+module lwdr.string_switch;
+
+//Copy pasted from the druntime
+
+int __cmp(T)(scope const T[] lhs, scope const T[] rhs) @trusted
+    if (__traits(isScalar, T))
+{
+    // Compute U as the implementation type for T
+    static if (is(T == ubyte) || is(T == void) || is(T == bool))
+        alias U = char;
+    else static if (is(T == wchar))
+        alias U = ushort;
+    else static if (is(T == dchar))
+        alias U = uint;
+    else static if (is(T == ifloat))
+        alias U = float;
+    else static if (is(T == idouble))
+        alias U = double;
+    else static if (is(T == ireal))
+        alias U = real;
+    else
+        alias U = T;
+
+    static if (is(U == char))
+    {
+        import core.internal.string : dstrcmp;
+        return dstrcmp(cast(char[]) lhs, cast(char[]) rhs);
+    }
+    else static if (!is(U == T))
+    {
+        // Reuse another implementation
+        return __cmp(cast(U[]) lhs, cast(U[]) rhs);
+    }
+    else
+    {
+        version (BigEndian)
+        static if (__traits(isUnsigned, T) ? !is(T == __vector) : is(T : P*, P))
+        {
+            if (!__ctfe)
+            {
+                import core.stdc.string : memcmp;
+                int c = memcmp(lhs.ptr, rhs.ptr, (lhs.length <= rhs.length ? lhs.length : rhs.length) * T.sizeof);
+                if (c)
+                    return c;
+                static if (size_t.sizeof <= uint.sizeof && T.sizeof >= 2)
+                    return cast(int) lhs.length - cast(int) rhs.length;
+                else
+                    return int(lhs.length > rhs.length) - int(lhs.length < rhs.length);
+            }
+        }
+
+        immutable len = lhs.length <= rhs.length ? lhs.length : rhs.length;
+        foreach (const u; 0 .. len)
+        {
+            auto a = lhs.ptr[u], b = rhs.ptr[u];
+            static if (is(T : creal))
+            {
+                // Use rt.cmath2._Ccmp instead ?
+                // Also: if NaN is present, numbers will appear equal.
+                auto r = (a.re > b.re) - (a.re < b.re);
+                if (!r) r = (a.im > b.im) - (a.im < b.im);
+            }
+            else
+            {
+                // This pattern for three-way comparison is better than conditional operators
+                // See e.g. https://godbolt.org/z/3j4vh1
+                const r = (a > b) - (a < b);
+            }
+            if (r) return r;
+        }
+        return (lhs.length > rhs.length) - (lhs.length < rhs.length);
+    }
+}
+
+// This function is called by the compiler when dealing with array
+// comparisons in the semantic analysis phase of CmpExp. The ordering
+// comparison is lowered to a call to this template.
+int __cmp(T1, T2)(T1[] s1, T2[] s2)
+if (!__traits(isScalar, T1) && !__traits(isScalar, T2))
+{
+    import core.internal.traits : Unqual;
+    alias U1 = Unqual!T1;
+    alias U2 = Unqual!T2;
+
+    static if (is(U1 == void) && is(U2 == void))
+        static @trusted ref inout(ubyte) at(inout(void)[] r, size_t i) { return (cast(inout(ubyte)*) r.ptr)[i]; }
+    else
+        static @trusted ref R at(R)(R[] r, size_t i) { return r.ptr[i]; }
+
+    // All unsigned byte-wide types = > dstrcmp
+    immutable len = s1.length <= s2.length ? s1.length : s2.length;
+
+    foreach (const u; 0 .. len)
+    {
+        static if (__traits(compiles, __cmp(at(s1, u), at(s2, u))))
+        {
+            auto c = __cmp(at(s1, u), at(s2, u));
+            if (c != 0)
+                return c;
+        }
+        else static if (__traits(compiles, at(s1, u).opCmp(at(s2, u))))
+        {
+            auto c = at(s1, u).opCmp(at(s2, u));
+            if (c != 0)
+                return c;
+        }
+        else static if (__traits(compiles, at(s1, u) < at(s2, u)))
+        {
+            if (int result = (at(s1, u) > at(s2, u)) - (at(s1, u) < at(s2, u)))
+                return result;
+        }
+        else
+        {
+            // TODO: fix this legacy bad behavior, see
+            // https://issues.dlang.org/show_bug.cgi?id=17244
+            static assert(is(U1 == U2), "Internal error.");
+            import core.stdc.string : memcmp;
+            auto c = (() @trusted => memcmp(&at(s1, u), &at(s2, u), U1.sizeof))();
+            if (c != 0)
+                return c;
+        }
+    }
+    return (s1.length > s2.length) - (s1.length < s2.length);
+}
+
+
+int __switch(T, caseLabels...)(/*in*/ const scope T[] condition) pure nothrow @safe @nogc
+{
+    // This closes recursion for other cases.
+    static if (caseLabels.length == 0)
+    {
+        return int.min;
+    }
+    else static if (caseLabels.length == 1)
+    {
+        return __cmp(condition, caseLabels[0]) == 0 ? 0 : int.min;
+    }
+    // To be adjusted after measurements
+    // Compile-time inlined binary search.
+    else static if (caseLabels.length < 7)
+    {
+        int r = void;
+        enum mid = cast(int)caseLabels.length / 2;
+        if (condition.length == caseLabels[mid].length)
+        {
+            r = __cmp(condition, caseLabels[mid]);
+            if (r == 0) return mid;
+        }
+        else
+        {
+            // Equivalent to (but faster than) condition.length > caseLabels[$ / 2].length ? 1 : -1
+            r = ((condition.length > caseLabels[mid].length) << 1) - 1;
+        }
+
+        if (r < 0)
+        {
+            // Search the left side
+            return __switch!(T, caseLabels[0 .. mid])(condition);
+        }
+        else
+        {
+            // Search the right side
+            return __switch!(T, caseLabels[mid + 1 .. $])(condition) + mid + 1;
+        }
+    }
+    else
+    {
+        // Need immutable array to be accessible in pure code, but case labels are
+        // currently coerced to the switch condition type (e.g. const(char)[]).
+        pure @trusted nothrow @nogc asImmutable(scope const(T[])[] items)
+        {
+            assert(__ctfe); // only @safe for CTFE
+            immutable T[][caseLabels.length] result = cast(immutable)(items[]);
+            return result;
+        }
+        static immutable T[][caseLabels.length] cases = asImmutable([caseLabels]);
+
+        // Run-time binary search in a static array of labels.
+        return __switchSearch!T(cases[], condition);
+    }
+}
+
+// binary search in sorted string cases, also see `__switch`.
+private int __switchSearch(T)(/*in*/ const scope T[][] cases, /*in*/ const scope T[] condition) pure nothrow @safe @nogc
+{
+    size_t low = 0;
+    size_t high = cases.length;
+
+    do
+    {
+        auto mid = (low + high) / 2;
+        int r = void;
+        if (condition.length == cases[mid].length)
+        {
+            r = __cmp(condition, cases[mid]);
+            if (r == 0) return cast(int) mid;
+        }
+        else
+        {
+            // Generates better code than "expr ? 1 : -1" on dmd and gdc, same with ldc
+            r = ((condition.length > cases[mid].length) << 1) - 1;
+        }
+
+        if (r > 0) low = mid + 1;
+        else high = mid;
+    }
+    while (low < high);
+
+    // Not found
+    return -1;
+}

--- a/source/object.d
+++ b/source/object.d
@@ -10,6 +10,7 @@ version(LWDR_DynamicArray)
 public import lifetime.array_ : _d_arraysetlengthTImpl, _d_newarrayU;
 
 
+public import lwdr.string_switch : __switch;
 public import core.internal.switch_ : __switch_error; //final switch
 
 

--- a/source/object.d
+++ b/source/object.d
@@ -9,6 +9,10 @@ import lifetime.throwable;
 version(LWDR_DynamicArray)
 public import lifetime.array_ : _d_arraysetlengthTImpl, _d_newarrayU;
 
+
+public import core.internal.switch_ : __switch_error; //final switch
+
+
 public import rt.arrcast : __ArrayCast;
 
 version (D_LP64)
@@ -86,8 +90,21 @@ extern(C) void _d_assert(string f, uint l) { rtosbackend_assert(f, l); }
 extern(C) void _d_assert_msg(string msg, string f, uint l) { rtosbackend_assertmsg(msg, f, l); }
 /// A D array was incorrectly accessed
 extern(C) void _d_arraybounds(string f, size_t l) {rtosbackend_arrayBoundFailure(f, l);}
-//final switch (available as assert is implemented)
-public import core.internal.switch_ : __switch_error;
+
+/// Called when an out of range slice of an array is created
+extern(C) void _d_arraybounds_slice(string file, uint line, size_t, size_t, size_t)
+{
+    // Ignore additional information for now
+    _d_arraybounds(file, line);
+}
+
+/// Called when an out of range array index is accessed
+extern(C) void _d_arraybounds_index(string file, uint line, size_t, size_t)
+{
+    // Ignore additional information for now
+    _d_arraybounds(file, line);
+}
+
 
 
 extern(C) bool _xopEquals(in void*, in void*) { return false; }


### PR DESCRIPTION
- final switch
- vector operations: `arr[]+= 50` 
- dup/idup  (Necessary for the vector operations)
- switch on strings